### PR TITLE
Adicionando validacao de string

### DIFF
--- a/app/Http/Controllers/StudentController.php
+++ b/app/Http/Controllers/StudentController.php
@@ -73,16 +73,19 @@ class StudentController extends Controller
         return response()->json(["message" => "Student deleted"], Response::HTTP_ACCEPTED);        
     }
 
-    private function validateRequest(Request $request): void {
+    private function validateRequest(Request $request): void 
+    {
         $rules = [
-            'name' => 'required|max:60',
-            'course' => 'required|max:60'
+            'name' => 'required|string|max:60',
+            'course' => 'required|string|max:60'
         ];
         
         $feedback = [
             'required' => 'O campo :attribute é obrigatório',
             'name.max' => 'O campo name deve ter no máximo 60 caracteres',
-            'course.max' => 'O campo course deve ter no máximo 60 caracteres'
+            'course.max' => 'O campo course deve ter no máximo 60 caracteres',
+            'name.string' => 'O campo name deve ser string',
+            'course.string' => 'O campo course deve ser string'
         ];
 
         $request->validate($rules, $feedback);


### PR DESCRIPTION
- Adicionado tipo do parâmetro para não permitir cadastros com outro tipo de dado. Ex:
`{
        "id": 5,
        "name": "123",
        "course": "Computing Science",
        "created_at": "2022-06-02T00:02:47.000000Z",
        "updated_at": "2022-06-02T00:02:47.000000Z"
    }`